### PR TITLE
Update imgur_downloader.py

### DIFF
--- a/imgurtofolder/imgur_downloader.py
+++ b/imgurtofolder/imgur_downloader.py
@@ -8,6 +8,7 @@ import os
 import re
 import requests
 import shutil
+from urllib.parse import urlparse
 
 log = logs.Log('downloader')
 
@@ -71,8 +72,8 @@ class Imgur_Downloader(Imgur):
                     self.download_tag(result, page=page, max_items=max_items)
 
         else:
-            log.info('Downloading image: %s' % url[url.rfind('/') + 1:])
-            self.download(url[url.rfind('/') + 1:], url, self.get_download_path())
+            log.info('Downloading image: %s' % os.path.basename(urlparse(url).path))
+            self.download(os.path.basename(urlparse(url).path), url, self.get_download_path())
 
     def get_image_link(self, image):
         if 'mp4' in image:


### PR DESCRIPTION
A long time ago I rotated some of my images, so Imgur added query strings to their URLs.

Log:
```
D:\utils\tools\Imgur-To-Folder-master>py imgurtofolder --download-account-images doliman100 --max-downloads 5000
...
[downloader](INFO) 05:37:09 PM: Downloading image: WrUcSQb.jpg?1
[downloader](INFO) 05:37:09 PM:         WrUcSQb.jpg?1, File Size: 0.36 MB
[main](INFO) 05:37:09 PM: Exception has occured
Traceback (most recent call last):
  File "D:\utils\tools\Imgur-To-Folder-master\imgurtofolder\__main__.py", line 186, in <module>
    main()
  File "D:\utils\tools\Imgur-To-Folder-master\imgurtofolder\__main__.py", line 175, in main
    downloader.download_account_images(args.download_account_images,
  File "D:\utils\tools\Imgur-To-Folder-master\imgurtofolder\imgur_downloader.py", line 239, in download_account_images
    self.parse_id(image['link'])
  File "D:\utils\tools\Imgur-To-Folder-master\imgurtofolder\imgur_downloader.py", line 75, in parse_id
    self.download(url[url.rfind('/') + 1:], url, self.get_download_path())
  File "D:\utils\tools\Imgur-To-Folder-master\imgurtofolder\imgur_downloader.py", line 257, in download
    with open(os.path.join(path, filename), 'wb') as image_file:
OSError: [Errno 22] Invalid argument: 'D:\\home\\media\\archive\\imgur\\WrUcSQb.jpg?1'
```
