### PR TITLE
Using pathlib to pull in requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+from pathlib import Path
 
 setup(
     name='ImgurToFolder',
@@ -17,7 +18,5 @@ setup(
         ]
     },
     package_data={},
-    install_requires=[
-        'requests'
-    ]
+    install_requires=Path('requirements.txt').read_text().splitlines(),
 )


### PR DESCRIPTION
- Using pathlib to pull in requirements in setup.py
- Quick and dirty way of getting the requirements in. Will refactor in the future.